### PR TITLE
Add wrap/unwrap offering and refactor shared chain/LI.FI utilities

### DIFF
--- a/src/seller/offerings/_shared/chains.ts
+++ b/src/seller/offerings/_shared/chains.ts
@@ -1,3 +1,6 @@
+import { mainnet, base, arbitrum } from "viem/chains";
+import type { Chain } from "viem";
+
 export type SupportedChain =
   | "ETHEREUM"
   | "BASE"
@@ -41,4 +44,91 @@ export function normalizeChain(input: string): SupportedChain | null {
 export function chainIdOf(input: string): number | null {
   const c = normalizeChain(input);
   return c ? CHAIN_ID[c] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Viem chain objects (only chains we can execute transactions on)
+// ---------------------------------------------------------------------------
+export const VIEM_CHAINS: Record<number, Chain> = {
+  1: mainnet,
+  8453: base,
+  42161: arbitrum,
+};
+
+// ---------------------------------------------------------------------------
+// RPC URLs — override via env vars, sensible public defaults otherwise
+// ---------------------------------------------------------------------------
+export function getRpcUrl(chainId: number): string {
+  switch (chainId) {
+    case 1:
+      return process.env.ETH_RPC_URL?.trim() || "https://eth.llamarpc.com";
+    case 8453:
+      return process.env.BASE_RPC_URL?.trim() || "https://mainnet.base.org";
+    case 42161:
+      return process.env.ARB_RPC_URL?.trim() || "https://arb1.arbitrum.io/rpc";
+    case 137:
+      return process.env.POLYGON_RPC_URL?.trim() || "https://polygon-rpc.com";
+    case 56:
+      return process.env.BSC_RPC_URL?.trim() || "https://bsc-dataseed.binance.org";
+    default:
+      throw new Error(`No RPC URL configured for chainId ${chainId}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WETH / Wrapped-native-token addresses per chain
+// ---------------------------------------------------------------------------
+export const WETH_ADDRESS: Record<number, `0x${string}`> = {
+  1: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+  8453: "0x4200000000000000000000000000000000000006",
+  42161: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+};
+
+// ---------------------------------------------------------------------------
+// Native token symbol per chain
+// ---------------------------------------------------------------------------
+export const NATIVE_TOKEN: Record<number, string> = {
+  1: "ETH",
+  8453: "ETH",
+  42161: "ETH",
+  137: "MATIC",
+  56: "BNB",
+};
+
+// ---------------------------------------------------------------------------
+// Common token addresses per chain (for synchronous lookups)
+// ---------------------------------------------------------------------------
+export const COMMON_TOKENS: Record<number, Record<string, `0x${string}`>> = {
+  1: {
+    USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    USDT: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    WBTC: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+  },
+  8453: {
+    USDC: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    WETH: "0x4200000000000000000000000000000000000006",
+    DAI: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+    USDbC: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
+  },
+  42161: {
+    USDC: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    "USDC.e": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+    USDT: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+    WETH: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    DAI: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+    WBTC: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+  },
+};
+
+/**
+ * Synchronous lookup for common token addresses.
+ * Returns undefined when the token is not in the hardcoded table.
+ */
+export function getCommonTokenAddress(
+  chainId: number,
+  symbol: string,
+): `0x${string}` | undefined {
+  return COMMON_TOKENS[chainId]?.[symbol.toUpperCase()];
 }

--- a/src/seller/offerings/_shared/erc20.ts
+++ b/src/seller/offerings/_shared/erc20.ts
@@ -1,8 +1,13 @@
 import { erc20Abi, type Address } from "viem";
-import { getBaseClients } from "./evm.js";
+import { getBaseClients, getChainClients } from "./evm.js";
 
-export async function getErc20Balance(token: Address, owner: Address) {
-  const { publicClient } = getBaseClients();
+function getClients(chainId?: number) {
+  if (chainId) return getChainClients(chainId);
+  return getBaseClients();
+}
+
+export async function getErc20Balance(token: Address, owner: Address, chainId?: number) {
+  const { publicClient } = getClients(chainId);
   return publicClient.readContract({
     address: token,
     abi: erc20Abi,
@@ -11,8 +16,8 @@ export async function getErc20Balance(token: Address, owner: Address) {
   }) as Promise<bigint>;
 }
 
-export async function getAllowance(token: Address, owner: Address, spender: Address) {
-  const { publicClient } = getBaseClients();
+export async function getAllowance(token: Address, owner: Address, spender: Address, chainId?: number) {
+  const { publicClient } = getClients(chainId);
   return publicClient.readContract({
     address: token,
     abi: erc20Abi,
@@ -21,10 +26,10 @@ export async function getAllowance(token: Address, owner: Address, spender: Addr
   }) as Promise<bigint>;
 }
 
-export async function ensureAllowanceExact(token: Address, spender: Address, amount: bigint) {
-  const { publicClient, walletClient, account } = getBaseClients();
+export async function ensureAllowanceExact(token: Address, spender: Address, amount: bigint, chainId?: number) {
+  const { publicClient, walletClient, account } = getClients(chainId);
 
-  const current = await getAllowance(token, account.address, spender);
+  const current = await getAllowance(token, account.address, spender, chainId);
   if (current >= amount) return { approved: false as const };
 
   const hash = await walletClient.writeContract({

--- a/src/seller/offerings/_shared/evm.ts
+++ b/src/seller/offerings/_shared/evm.ts
@@ -1,6 +1,7 @@
 import { createPublicClient, createWalletClient, http, type Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base } from "viem/chains";
+import { VIEM_CHAINS, getRpcUrl } from "./chains.js";
 
 export const BASE_RPC_URL = process.env.BASE_RPC_URL?.trim() || "https://mainnet.base.org";
 
@@ -18,4 +19,22 @@ export function getBaseClients() {
   const walletClient = createWalletClient({ chain: base, transport, account });
 
   return { publicClient, walletClient, account };
+}
+
+/**
+ * Create viem public + wallet clients for any supported chain.
+ * Supported: Ethereum (1), Base (8453), Arbitrum (42161).
+ */
+export function getChainClients(chainId: number) {
+  const chain = VIEM_CHAINS[chainId];
+  if (!chain) throw new Error(`No viem chain config for chainId ${chainId}. Supported: 1, 8453, 42161`);
+
+  const account = requireExecutorAccount();
+  const rpcUrl = getRpcUrl(chainId);
+  const transport = http(rpcUrl, { timeout: 30_000 });
+
+  const publicClient = createPublicClient({ chain, transport });
+  const walletClient = createWalletClient({ chain, transport, account });
+
+  return { publicClient, walletClient, account, chain };
 }

--- a/src/seller/offerings/bridge/offering.json
+++ b/src/seller/offerings/bridge/offering.json
@@ -1,9 +1,10 @@
 {
   "name": "bridge",
-  "description": "Seller-executed bridge/swap via LI.FI. Buyer transfers funds to executor first (ACP requiredFunds). Supports fromChain=base, toChain in {ethereum, arbitrum, polygon, bsc}. Optional: toToken for cross-chain swap (DEX+bridge aggregation).",
+  "description": "Seller-executed cross-chain bridge via LI.FI. Buyer transfers funds to executor (ACP requiredFunds). Supports fromChain in {ethereum, base, arbitrum}, toChain in {ethereum, base, arbitrum, polygon, bsc}. Any token supported via LI.FI DEX+bridge aggregation. Optional toToken for cross-chain swap.",
   "jobFee": 0.2,
   "jobFeeType": "percentage",
   "requiredFunds": true,
+  "slaMinutes": 10,
   "requirement": {
     "type": "object",
     "properties": {
@@ -13,22 +14,22 @@
       },
       "token": {
         "type": "string",
-        "description": "Source token symbol on Base (MVP: USDC).",
+        "description": "Source token symbol (e.g. USDC, WETH, USDT, DAI) or contract address.",
         "default": "USDC"
       },
       "toToken": {
         "type": "string",
-        "description": "Destination token symbol on target chain (optional). If omitted, defaults to token (bridge only)."
+        "description": "Destination token symbol on target chain (optional). If omitted, defaults to same as token."
       },
       "fromChain": {
         "type": "string",
-        "description": "Source chain (executor-only MVP: base).",
-        "enum": ["base"]
+        "description": "Source chain for bridge execution.",
+        "enum": ["ethereum", "base", "arbitrum"]
       },
       "toChain": {
         "type": "string",
         "description": "Destination chain.",
-        "enum": ["ethereum", "arbitrum", "polygon", "bsc"]
+        "enum": ["ethereum", "base", "arbitrum", "polygon", "bsc"]
       },
       "receiver": {
         "type": "string",

--- a/src/seller/offerings/lifi_bridge_quote/handlers.ts
+++ b/src/seller/offerings/lifi_bridge_quote/handlers.ts
@@ -18,15 +18,15 @@ export async function executeJob(requirements: any) {
   const parsed = parseAgentCommand(requirements.command);
 
   if (parsed.kind === "swap") {
-    const chainId = await getChainId(parsed.chain);
+    const chainId = getChainId(parsed.chain);
     const fromTok = await getToken(chainId, parsed.tokenIn);
     const toTok = await getToken(chainId, parsed.tokenOut);
 
     const fromAmount = parseUnitsDecimal(parsed.amount, Number(fromTok.decimals));
-    const fromAddress = parsed.sender ?? parsed.receiver; // fallback
+    const fromAddress = parsed.sender ?? parsed.receiver;
     const quote = await getQuote({
-      fromChainId: chainId,
-      toChainId: chainId,
+      fromChain: chainId,
+      toChain: chainId,
       fromToken: fromTok.address,
       toToken: toTok.address,
       fromAmount,
@@ -55,18 +55,22 @@ export async function executeJob(requirements: any) {
     };
   }
 
+  if (parsed.kind === "wrap") {
+    throw new Error("Wrap/unwrap is not supported by this offering. Use the 'wrap' offering instead.");
+  }
+
   // bridge
-  const fromChainId = await getChainId(parsed.fromChain);
-  const toChainId = await getChainId(parsed.toChain);
+  const fromChainId = getChainId(parsed.fromChain);
+  const toChainId = getChainId(parsed.toChain);
 
   const fromTok = await getToken(fromChainId, parsed.tokenIn);
   const toTok = await getToken(toChainId, parsed.tokenOut);
 
   const fromAmount = parseUnitsDecimal(parsed.amount, Number(fromTok.decimals));
-  const fromAddress = parsed.sender ?? parsed.receiver; // fallback
+  const fromAddress = parsed.sender ?? parsed.receiver;
   const quote = await getQuote({
-    fromChainId,
-    toChainId,
+    fromChain: fromChainId,
+    toChain: toChainId,
     fromToken: fromTok.address,
     toToken: toTok.address,
     fromAmount,

--- a/src/seller/offerings/wrap/handlers.ts
+++ b/src/seller/offerings/wrap/handlers.ts
@@ -1,0 +1,391 @@
+import type { ExecuteJobResult, ValidationResult } from "../../runtime/offeringTypes.js";
+import { getAddress, parseEther, formatEther, erc20Abi } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { getChainClients } from "../_shared/evm.js";
+import { chainIdOf, WETH_ADDRESS, NATIVE_TOKEN, VIEM_CHAINS } from "../_shared/chains.js";
+import { getQuote } from "../_shared/lifi.js";
+import { parseWrapCommand, type WrapRequest } from "../_shared/command.js";
+
+// ---------------------------------------------------------------------------
+// WETH ABI (deposit = wrap, withdraw = unwrap)
+// ---------------------------------------------------------------------------
+const WETH_ABI = [
+  {
+    name: "deposit",
+    type: "function",
+    stateMutability: "payable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    name: "withdraw",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "wad", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    name: "balanceOf",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "balance", type: "uint256" }],
+  },
+  {
+    name: "transfer",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    outputs: [{ name: "ok", type: "bool" }],
+  },
+] as const;
+
+// LI.FI uses zero address for native tokens
+const NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const SUPPORTED_CHAINS = ["ethereum", "base", "arbitrum"];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function env(name: string): string {
+  const v = process.env[name];
+  if (!v || !v.trim()) throw new Error(`Missing env: ${name}`);
+  return v.trim();
+}
+
+function isHexAddress(s: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/.test(s);
+}
+
+function coerceRequest(req: any): { action: "wrap" | "unwrap"; amountHuman: string; chain: string; receiver: string; dryRun: boolean } {
+  // Support command string
+  if (typeof req === "string") {
+    const r = parseWrapCommand(req);
+    return { action: r.action, amountHuman: r.amount, chain: r.chain, receiver: r.receiver, dryRun: false };
+  }
+  if (typeof req?.command === "string" && req.command.trim()) {
+    const r = parseWrapCommand(req.command);
+    return { action: r.action, amountHuman: r.amount, chain: r.chain, receiver: r.receiver, dryRun: Boolean(req?.dryRun ?? false) };
+  }
+
+  // Structured request
+  const action = String(req?.action ?? "").toLowerCase();
+  if (action !== "wrap" && action !== "unwrap") {
+    throw new Error("action must be 'wrap' or 'unwrap'");
+  }
+  return {
+    action: action as "wrap" | "unwrap",
+    amountHuman: String(req?.amountHuman ?? "").trim(),
+    chain: String(req?.chain ?? "").trim(),
+    receiver: String(req?.receiver ?? "").trim(),
+    dryRun: Boolean(req?.dryRun ?? false),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validate
+// ---------------------------------------------------------------------------
+export function validateRequirements(req: any): ValidationResult {
+  try {
+    const r = coerceRequest(req);
+
+    if (!r.amountHuman || Number(r.amountHuman) <= 0) {
+      return { valid: false, reason: "amountHuman must be a positive number" };
+    }
+
+    if (!SUPPORTED_CHAINS.includes(r.chain.toLowerCase())) {
+      return { valid: false, reason: `Unsupported chain: ${r.chain}. Supported: ${SUPPORTED_CHAINS.join(", ")}` };
+    }
+
+    const chainId = chainIdOf(r.chain);
+    if (!chainId || !WETH_ADDRESS[chainId]) {
+      return { valid: false, reason: `No WETH address configured for chain: ${r.chain}` };
+    }
+
+    if (!isHexAddress(r.receiver)) {
+      return { valid: false, reason: "receiver must be a valid 0x address" };
+    }
+
+    return { valid: true };
+  } catch (e: any) {
+    return { valid: false, reason: e?.message ?? "Invalid request" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request payment
+// ---------------------------------------------------------------------------
+export function requestPayment(req: any): string {
+  try {
+    const r = coerceRequest(req);
+    const nativeSymbol = NATIVE_TOKEN[chainIdOf(r.chain)!] ?? "ETH";
+    if (r.action === "wrap") {
+      return `To wrap: send ${r.amountHuman} ${nativeSymbol} (${r.chain}) to executor. Will return WETH to receiver=${r.receiver}.`;
+    }
+    return `To unwrap: send ${r.amountHuman} WETH (${r.chain}) to executor. Will return ${nativeSymbol} to receiver=${r.receiver}.`;
+  } catch {
+    return "Wrap/unwrap request accepted.";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request additional funds
+// ---------------------------------------------------------------------------
+export function requestAdditionalFunds(req: any): {
+  content?: string;
+  amount: number;
+  tokenAddress: string;
+  recipient: string;
+} {
+  const pk = env("EXECUTOR_PRIVATE_KEY");
+  const account = privateKeyToAccount(pk as `0x${string}`);
+  const recipient = account.address;
+
+  const r = coerceRequest(req);
+  const amountNum = Number(r.amountHuman);
+  const chainId = chainIdOf(r.chain)!;
+  const nativeSymbol = NATIVE_TOKEN[chainId] ?? "ETH";
+
+  if (r.action === "wrap") {
+    // Need native ETH to wrap
+    return {
+      content: `Send ${r.amountHuman} ${nativeSymbol} (${r.chain}) to executor=${recipient} for wrapping.`,
+      amount: amountNum,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+      recipient,
+    };
+  }
+
+  // Need WETH to unwrap
+  const wethAddr = WETH_ADDRESS[chainId];
+  return {
+    content: `Send ${r.amountHuman} WETH (${r.chain}) to executor=${recipient} for unwrapping.`,
+    amount: amountNum,
+    tokenAddress: wethAddr,
+    recipient,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Execute — try LI.FI first, fallback to direct WETH contract
+// ---------------------------------------------------------------------------
+export async function executeJob(req: any): Promise<ExecuteJobResult> {
+  try {
+    const r = coerceRequest(req);
+    const pk = env("EXECUTOR_PRIVATE_KEY");
+    const account = privateKeyToAccount(pk as `0x${string}`);
+
+    const chainId = chainIdOf(r.chain);
+    if (!chainId) {
+      return { deliverable: { type: "json", value: { ok: false, error: `Unsupported chain: ${r.chain}` } } };
+    }
+    if (!VIEM_CHAINS[chainId]) {
+      return { deliverable: { type: "json", value: { ok: false, error: `Cannot execute on chain: ${r.chain}` } } };
+    }
+
+    const wethAddress = WETH_ADDRESS[chainId];
+    if (!wethAddress) {
+      return { deliverable: { type: "json", value: { ok: false, error: `No WETH configured for chain: ${r.chain}` } } };
+    }
+
+    const { publicClient, walletClient, chain } = getChainClients(chainId);
+    const receiver = getAddress(r.receiver);
+    const amountWei = parseEther(r.amountHuman);
+
+    // Check balance
+    if (r.action === "wrap") {
+      const ethBalance = await publicClient.getBalance({ address: account.address });
+      if (ethBalance < amountWei) {
+        return {
+          deliverable: {
+            type: "json",
+            value: {
+              ok: false,
+              error: "Insufficient native balance for wrap",
+              executor: account.address,
+              chain: r.chain,
+              needed: amountWei.toString(),
+              have: ethBalance.toString(),
+            },
+          },
+        };
+      }
+    } else {
+      const wethBalance: bigint = await publicClient.readContract({
+        address: wethAddress,
+        abi: WETH_ABI,
+        functionName: "balanceOf",
+        args: [account.address],
+      });
+      if (wethBalance < amountWei) {
+        return {
+          deliverable: {
+            type: "json",
+            value: {
+              ok: false,
+              error: "Insufficient WETH balance for unwrap",
+              executor: account.address,
+              chain: r.chain,
+              needed: amountWei.toString(),
+              have: wethBalance.toString(),
+            },
+          },
+        };
+      }
+    }
+
+    if (r.dryRun) {
+      return {
+        deliverable: {
+          type: "json",
+          value: {
+            ok: true,
+            mode: "dryRun",
+            action: r.action,
+            executor: account.address,
+            chain: r.chain,
+            chainId,
+            amountHuman: r.amountHuman,
+            amountWei: amountWei.toString(),
+            wethAddress,
+            receiver,
+          },
+        },
+      };
+    }
+
+    // --- Strategy 1: Try LI.FI swap (ETH <-> WETH on same chain) ---
+    let lifiUsed = false;
+    let txHash: string | undefined;
+
+    try {
+      const fromToken = r.action === "wrap" ? NATIVE_TOKEN_ADDRESS : wethAddress;
+      const toToken = r.action === "wrap" ? wethAddress : NATIVE_TOKEN_ADDRESS;
+
+      const quote = await getQuote({
+        fromChain: chainId,
+        toChain: chainId,
+        fromToken,
+        toToken,
+        fromAmount: amountWei.toString(),
+        fromAddress: account.address,
+        toAddress: receiver,
+        slippage: 0.001,
+        integrator: "lifi-api",
+      });
+
+      const txReq = quote?.transactionRequest;
+      if (txReq?.to && txReq?.data) {
+        // LI.FI returned a valid transactionRequest — broadcast it
+        txHash = await walletClient.sendTransaction({
+          account,
+          to: getAddress(txReq.to),
+          data: txReq.data,
+          value: BigInt(txReq.value ?? "0x0"),
+          gas: txReq.gasLimit ? BigInt(txReq.gasLimit) : undefined,
+          chain,
+        });
+        lifiUsed = true;
+      }
+    } catch (lifiErr: any) {
+      // LI.FI failed — fall through to direct WETH contract
+      console.log(`[wrap] LI.FI failed, falling back to direct WETH contract: ${lifiErr?.message ?? lifiErr}`);
+    }
+
+    // --- Strategy 2: Direct WETH contract (Uniswap-compatible fallback) ---
+    if (!txHash) {
+      if (r.action === "wrap") {
+        // Step 1: WETH.deposit() — wraps ETH to WETH (credited to executor)
+        txHash = await walletClient.writeContract({
+          account,
+          address: wethAddress,
+          abi: WETH_ABI,
+          functionName: "deposit",
+          value: amountWei,
+          chain,
+        });
+
+        await publicClient.waitForTransactionReceipt({ hash: txHash as `0x${string}` });
+
+        // Step 2: If receiver != executor, transfer WETH to receiver
+        if (receiver.toLowerCase() !== account.address.toLowerCase()) {
+          const transferHash = await walletClient.writeContract({
+            account,
+            address: wethAddress,
+            abi: WETH_ABI,
+            functionName: "transfer",
+            args: [receiver, amountWei],
+            chain,
+          });
+          await publicClient.waitForTransactionReceipt({ hash: transferHash });
+        }
+      } else {
+        // Step 1: WETH.withdraw() — unwraps WETH to ETH (credited to executor)
+        txHash = await walletClient.writeContract({
+          account,
+          address: wethAddress,
+          abi: WETH_ABI,
+          functionName: "withdraw",
+          args: [amountWei],
+          chain,
+        });
+
+        await publicClient.waitForTransactionReceipt({ hash: txHash as `0x${string}` });
+
+        // Step 2: If receiver != executor, send ETH to receiver
+        if (receiver.toLowerCase() !== account.address.toLowerCase()) {
+          const sendHash = await walletClient.sendTransaction({
+            account,
+            to: receiver,
+            value: amountWei,
+            chain,
+          });
+          await publicClient.waitForTransactionReceipt({ hash: sendHash });
+        }
+      }
+    } else {
+      // Wait for LI.FI tx
+      await publicClient.waitForTransactionReceipt({ hash: txHash as `0x${string}` });
+    }
+
+    const nativeSymbol = NATIVE_TOKEN[chainId] ?? "ETH";
+    return {
+      deliverable: {
+        type: "json",
+        value: {
+          ok: true,
+          mode: "executed",
+          action: r.action,
+          method: lifiUsed ? "lifi" : "weth_contract_direct",
+          executor: account.address,
+          chain: r.chain,
+          chainId,
+          amountHuman: r.amountHuman,
+          amountWei: amountWei.toString(),
+          wethAddress,
+          receiver,
+          txHash,
+          description: r.action === "wrap"
+            ? `Wrapped ${r.amountHuman} ${nativeSymbol} to WETH on ${r.chain}`
+            : `Unwrapped ${r.amountHuman} WETH to ${nativeSymbol} on ${r.chain}`,
+        },
+      },
+    };
+  } catch (e: any) {
+    const err = e?.response?.data ?? e?.message ?? e;
+    return {
+      deliverable: {
+        type: "json",
+        value: {
+          ok: false,
+          error: "Wrap/unwrap execution failed",
+          details: typeof err === "object" ? JSON.stringify(err) : String(err),
+        },
+      },
+    };
+  }
+}

--- a/src/seller/offerings/wrap/offering.json
+++ b/src/seller/offerings/wrap/offering.json
@@ -1,0 +1,41 @@
+{
+  "name": "wrap",
+  "description": "Wrap native token (ETH) to WETH or unwrap WETH to native ETH. Executor-run on Ethereum, Base, and Arbitrum. Uses LI.FI DEX aggregation with direct WETH contract fallback (Uniswap-compatible).",
+  "jobFee": 0.1,
+  "jobFeeType": "fixed",
+  "requiredFunds": true,
+  "slaMinutes": 5,
+  "requirement": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "description": "wrap (native ETH -> WETH) or unwrap (WETH -> native ETH).",
+        "enum": ["wrap", "unwrap"]
+      },
+      "amountHuman": {
+        "type": "string",
+        "description": "Human-readable amount (e.g. '0.5' for 0.5 ETH/WETH)."
+      },
+      "chain": {
+        "type": "string",
+        "description": "Chain to wrap/unwrap on.",
+        "enum": ["ethereum", "base", "arbitrum"]
+      },
+      "receiver": {
+        "type": "string",
+        "description": "Receiver address for the wrapped/unwrapped tokens."
+      },
+      "command": {
+        "type": "string",
+        "description": "Alternative: natural-language command string. Example: 'wrap 5 ETH on base receiver 0x...'"
+      },
+      "dryRun": {
+        "type": "boolean",
+        "description": "If true, returns quote without broadcasting.",
+        "default": false
+      }
+    },
+    "required": ["amountHuman", "action", "chain", "receiver"]
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new wrap/unwrap offering for converting between native tokens (ETH) and wrapped tokens (WETH) on Ethereum, Base, and Arbitrum. It also refactors shared utilities to support multi-chain execution and improves code organization.

## Key Changes

### New Wrap/Unwrap Offering
- **New file**: `src/seller/offerings/wrap/handlers.ts` — Complete implementation with:
  - `validateRequirements()` — Validates action, amount, chain, and receiver
  - `requestPayment()` — Generates user-friendly payment instructions
  - `requestAdditionalFunds()` — Requests native or WETH tokens from ACP
  - `executeJob()` — Executes wrap/unwrap with dual strategy:
    - Primary: LI.FI DEX aggregation for optimal routing
    - Fallback: Direct WETH contract calls (Uniswap-compatible)
  - Supports both structured requests and natural-language command strings
  - Includes dry-run mode for quote-only operations

- **New file**: `src/seller/offerings/wrap/offering.json` — Offering metadata with schema definition

### Refactored Shared Utilities
- **`_shared/chains.ts`** — Enhanced with:
  - `VIEM_CHAINS` — Map of supported chain IDs to viem chain objects (Ethereum, Base, Arbitrum)
  - `getRpcUrl()` — Centralized RPC URL resolution with env var overrides
  - `WETH_ADDRESS` — WETH contract addresses per chain
  - `NATIVE_TOKEN` — Native token symbols per chain
  - `COMMON_TOKENS` — Hardcoded token address lookup table for synchronous resolution
  - `getCommonTokenAddress()` — Helper for token address lookups

- **`_shared/evm.ts`** — Added:
  - `getChainClients()` — Creates viem clients for any supported chain (replaces hardcoded Base-only logic)

- **`_shared/command.ts`** — Extended with:
  - `WrapRequest` type definition
  - `parseWrapCommand()` — Parses wrap/unwrap command strings (e.g., "wrap 5 ETH on base receiver 0x...")
  - Updated `AgentCommand` union to include wrap/unwrap commands

- **`_shared/erc20.ts`** — Updated:
  - `getErc20Balance()` and `getAllowance()` now accept optional `chainId` parameter for multi-chain support

### Bridge Offering Updates
- **`bridge/handlers.ts`** — Refactored to use new shared utilities:
  - Replaced hardcoded Base-only logic with multi-chain support (Ethereum, Base, Arbitrum as source chains)
  - Uses `getChainClients()` instead of inline viem client creation
  - Uses `getToken()` and `getQuote()` from shared LI.FI utilities
  - Uses `getCommonTokenAddress()` for synchronous token lookups
  - Expanded validation to support multiple source chains
  - Improved error handling and balance checking

- **`bridge/offering.json`** — Updated description to reflect multi-chain support

### Quote Offering Updates
- **`lifi_bridge_quote/handlers.ts`** — Minor updates:
  - Changed `getChainId()` calls to use synchronous version
  - Updated `getQuote()` parameter names (`fromChainId` → `fromChain`, `toChainId` → `toChain`)
  - Added wrap/unwrap command rejection with helpful error message

## Notable Implementation Details

1. **Dual-Strategy Execution**: Wrap/unwrap uses LI.FI first for optimal routing, with automatic fallback to direct WETH contract if LI.FI fails
2. **Receiver Flexibility**: If receiver differs from executor, tokens are transferred in a second transaction
3. **Synchronous Token Lookup**: `COMMON_TOKENS` table enables fast token address resolution without API calls
4. **Command String Support**: Both offerings support natural-language command parsing for

https://claude.ai/code/session_01VkZJhhaiefwa92zxvfbboB