### PR TITLE
Expand swap/wrap/bridge offerings to Polygon & BSC with executor-run swaps

### DIFF
--- a/src/seller/offerings/_shared/chains.ts
+++ b/src/seller/offerings/_shared/chains.ts
@@ -1,4 +1,4 @@
-import { mainnet, base, arbitrum } from "viem/chains";
+import { mainnet, base, arbitrum, polygon, bsc } from "viem/chains";
 import type { Chain } from "viem";
 
 export type SupportedChain =
@@ -53,6 +53,8 @@ export const VIEM_CHAINS: Record<number, Chain> = {
   1: mainnet,
   8453: base,
   42161: arbitrum,
+  137: polygon,
+  56: bsc,
 };
 
 // ---------------------------------------------------------------------------
@@ -82,6 +84,8 @@ export const WETH_ADDRESS: Record<number, `0x${string}`> = {
   1: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   8453: "0x4200000000000000000000000000000000000006",
   42161: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+  137: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",  // WMATIC
+  56: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",   // WBNB
 };
 
 // ---------------------------------------------------------------------------
@@ -119,6 +123,24 @@ export const COMMON_TOKENS: Record<number, Record<string, `0x${string}`>> = {
     WETH: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     DAI: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     WBTC: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+  },
+  137: {
+    USDC: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+    "USDC.e": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+    USDT: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+    WMATIC: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+    WETH: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+    DAI: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+    WBTC: "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+  },
+  56: {
+    USDC: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+    USDT: "0x55d398326f99059fF775485246999027B3197955",
+    WBNB: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+    BUSD: "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+    ETH: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
+    BTCB: "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
+    DAI: "0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3",
   },
 };
 

--- a/src/seller/offerings/_shared/evm.ts
+++ b/src/seller/offerings/_shared/evm.ts
@@ -23,11 +23,11 @@ export function getBaseClients() {
 
 /**
  * Create viem public + wallet clients for any supported chain.
- * Supported: Ethereum (1), Base (8453), Arbitrum (42161).
+ * Supported: Ethereum (1), Base (8453), Arbitrum (42161), Polygon (137), BSC (56).
  */
 export function getChainClients(chainId: number) {
   const chain = VIEM_CHAINS[chainId];
-  if (!chain) throw new Error(`No viem chain config for chainId ${chainId}. Supported: 1, 8453, 42161`);
+  if (!chain) throw new Error(`No viem chain config for chainId ${chainId}. Supported: 1, 8453, 42161, 137, 56`);
 
   const account = requireExecutorAccount();
   const rpcUrl = getRpcUrl(chainId);

--- a/src/seller/offerings/bridge/handlers.ts
+++ b/src/seller/offerings/bridge/handlers.ts
@@ -8,7 +8,7 @@ import { getToken, getQuote } from "../_shared/lifi.js";
 // ---------------------------------------------------------------------------
 // Supported chains for executor-run bridge
 // ---------------------------------------------------------------------------
-const SUPPORTED_FROM_CHAINS = ["ethereum", "base", "arbitrum"];
+const SUPPORTED_FROM_CHAINS = ["ethereum", "base", "arbitrum", "polygon", "bsc"];
 const SUPPORTED_TO_CHAINS = ["ethereum", "base", "arbitrum", "polygon", "bsc"];
 
 // ---------------------------------------------------------------------------
@@ -160,9 +160,8 @@ export async function executeJob(req: any): Promise<ExecuteJobResult> {
       return { deliverable: { type: "json", value: { ok: false, error: `Unsupported toChain=${toChainKey}` } } };
     }
 
-    // We need a viem chain to execute — only ETH/Base/ARB
     if (!VIEM_CHAINS[fromChainId]) {
-      return { deliverable: { type: "json", value: { ok: false, error: `Cannot execute on chainId=${fromChainId}. Executor supports: Ethereum, Base, Arbitrum.` } } };
+      return { deliverable: { type: "json", value: { ok: false, error: `Cannot execute on chainId=${fromChainId}. Executor supports: Ethereum, Base, Arbitrum, Polygon, BSC.` } } };
     }
 
     // Get chain clients for the source chain

--- a/src/seller/offerings/bridge/offering.json
+++ b/src/seller/offerings/bridge/offering.json
@@ -1,7 +1,7 @@
 {
   "name": "bridge",
-  "description": "Seller-executed cross-chain bridge via LI.FI. Buyer transfers funds to executor (ACP requiredFunds). Supports fromChain in {ethereum, base, arbitrum}, toChain in {ethereum, base, arbitrum, polygon, bsc}. Any token supported via LI.FI DEX+bridge aggregation. Optional toToken for cross-chain swap.",
-  "jobFee": 0.2,
+  "description": "Seller-executed cross-chain bridge via LI.FI. Buyer transfers funds to executor (ACP requiredFunds). Supports fromChain and toChain in {ethereum, base, arbitrum, polygon, bsc}. Any token supported via LI.FI DEX+bridge aggregation. Optional toToken for cross-chain swap.",
+  "jobFee": 1,
   "jobFeeType": "percentage",
   "requiredFunds": true,
   "slaMinutes": 10,
@@ -24,7 +24,7 @@
       "fromChain": {
         "type": "string",
         "description": "Source chain for bridge execution.",
-        "enum": ["ethereum", "base", "arbitrum"]
+        "enum": ["ethereum", "base", "arbitrum", "polygon", "bsc"]
       },
       "toChain": {
         "type": "string",

--- a/src/seller/offerings/swap/offering.json
+++ b/src/seller/offerings/swap/offering.json
@@ -1,25 +1,49 @@
 {
   "name": "swap",
-  "description": "Generate LI.FI swap quote + transactionRequest for same-chain token swap via DEX aggregation. Example: swap 5 USDC to ETH on base receiver 0x...",
-  "jobFee": 0.2,
-  "jobFeeType": "fixed",
+  "description": "Seller-executed same-chain token swap via LI.FI DEX aggregation. Buyer transfers funds to executor (ACP requiredFunds). Supports chains: ethereum, base, arbitrum, polygon, bsc. Any token supported via LI.FI.",
+  "jobFee": 1,
+  "jobFeeType": "percentage",
+  "requiredFunds": true,
   "slaMinutes": 5,
-  "requiredFunds": false,
   "requirement": {
     "type": "object",
     "properties": {
+      "amountHuman": {
+        "type": "string",
+        "description": "Human-readable amount (e.g. '5' for 5 USDC)."
+      },
+      "tokenIn": {
+        "type": "string",
+        "description": "Source token symbol (e.g. USDC, WETH, USDT, DAI) or contract address."
+      },
+      "tokenOut": {
+        "type": "string",
+        "description": "Destination token symbol or contract address."
+      },
+      "chain": {
+        "type": "string",
+        "description": "Chain to execute swap on.",
+        "enum": ["ethereum", "base", "arbitrum", "polygon", "bsc"]
+      },
+      "receiver": {
+        "type": "string",
+        "description": "Receiver address for the swapped tokens."
+      },
+      "slippage": {
+        "type": "number",
+        "description": "Slippage as decimal (0.005=0.5%) OR percent (0.5=0.5%). Default 0.5%.",
+        "default": 0.005
+      },
       "command": {
         "type": "string",
-        "description": "Example: swap 5 USDC to ETH on base receiver 0x0000000000000000000000000000000000000000"
+        "description": "Alternative: natural-language command. Example: 'swap 5 USDC to ETH on base receiver 0x...'"
       },
-      "amount": { "type": "string" },
-      "tokenIn": { "type": "string", "description": "Source token symbol or address" },
-      "tokenOut": { "type": "string", "description": "Destination token symbol or address" },
-      "chain": { "type": "string", "description": "Chain name (base, ethereum, arbitrum, polygon, bsc)" },
-      "receiver": { "type": "string" },
-      "sender": { "type": "string" },
-      "slippage": { "type": "number" }
-    }
-  },
-  "deliverable": "string"
+      "dryRun": {
+        "type": "boolean",
+        "description": "If true, only returns quote/txRequest without broadcasting.",
+        "default": false
+      }
+    },
+    "required": ["amountHuman", "tokenIn", "tokenOut", "chain", "receiver"]
+  }
 }

--- a/src/seller/offerings/wrap/offering.json
+++ b/src/seller/offerings/wrap/offering.json
@@ -1,8 +1,8 @@
 {
   "name": "wrap",
-  "description": "Wrap native token (ETH) to WETH or unwrap WETH to native ETH. Executor-run on Ethereum, Base, and Arbitrum. Uses LI.FI DEX aggregation with direct WETH contract fallback (Uniswap-compatible).",
-  "jobFee": 0.1,
-  "jobFeeType": "fixed",
+  "description": "Wrap native token to wrapped version (e.g. ETH->WETH, MATIC->WMATIC, BNB->WBNB) or unwrap back. Executor-run on Ethereum, Base, Arbitrum, Polygon, and BSC. Uses LI.FI DEX aggregation with direct contract fallback.",
+  "jobFee": 1,
+  "jobFeeType": "percentage",
   "requiredFunds": true,
   "slaMinutes": 5,
   "requirement": {
@@ -10,7 +10,7 @@
     "properties": {
       "action": {
         "type": "string",
-        "description": "wrap (native ETH -> WETH) or unwrap (WETH -> native ETH).",
+        "description": "wrap (native -> wrapped) or unwrap (wrapped -> native).",
         "enum": ["wrap", "unwrap"]
       },
       "amountHuman": {
@@ -20,7 +20,7 @@
       "chain": {
         "type": "string",
         "description": "Chain to wrap/unwrap on.",
-        "enum": ["ethereum", "base", "arbitrum"]
+        "enum": ["ethereum", "base", "arbitrum", "polygon", "bsc"]
       },
       "receiver": {
         "type": "string",


### PR DESCRIPTION
## Summary
This PR significantly expands the swap offering from a quote-only service to a fully executor-run implementation, and extends all three offerings (swap, wrap, bridge) to support Polygon and BSC chains. The swap offering now handles token approvals, balance checks, and transaction execution with dry-run capability.

## Key Changes

### Swap Offering (`src/seller/offerings/swap/`)
- **Converted from quote-only to executor-run**: The swap handler now executes transactions on-chain instead of just returning a quote
- **Added executor wallet integration**: Uses `EXECUTOR_PRIVATE_KEY` environment variable to sign and broadcast swap transactions
- **Implemented ERC-20 approval handling**: Automatically approves spenders extracted from LI.FI quotes before executing swaps
- **Added balance validation**: Checks executor has sufficient token balance before attempting swap
- **Introduced dry-run mode**: New `dryRun` parameter allows testing without broadcasting
- **Enhanced request coercion**: Renamed `amount` to `amountHuman` for clarity; removed `sender` field (uses executor address)
- **Improved error handling**: Returns structured JSON responses with detailed error information
- **Updated offering metadata**: Changed from fixed 0.2 fee to 1% percentage fee; marked `requiredFunds: true`

### Chain Support Expansion
- **Added Polygon (137) and BSC (56)** to:
  - `VIEM_CHAINS` mapping
  - `WETH_ADDRESS` (WMATIC for Polygon, WBNB for BSC)
  - `COMMON_TOKENS` lookup table with native and popular tokens
  - `SUPPORTED_CHAINS` in swap, wrap, and bridge handlers
- **Updated wrap offering**: Added `WRAPPED_SYMBOL` mapping to display correct wrapped token names per chain (WETH, WMATIC, WBNB)
- **Updated bridge offering**: Extended `SUPPORTED_FROM_CHAINS` to include Polygon and BSC

### Helper Functions & Utilities
- **New `toSlippageDecimal()`**: Normalizes slippage input (handles both decimal and percentage formats)
- **New `extractSpenders()`**: Extracts approval addresses from LI.FI quote structure
- **New `requestPayment()` export**: Returns human-readable payment request message
- **New `requestAdditionalFunds()` export**: Returns structured fund request with token address and recipient
- **Updated `env()` helper**: Validates environment variables are present and non-empty

### Response Format Changes
- **Swap deliverable**: Changed from string to structured JSON object with `type: "json"` and detailed `value` containing execution status, approvals, transaction hash, and LI.FI metadata
- **Consistent error responses**: All error paths return `{ ok: false, error: "...", details: "..." }` structure

### Offering Schema Updates
- **Swap offering.json**: Added `amountHuman`, `slippage`, and `dryRun` properties; removed `sender`; added chain enum constraint; marked fields as required
- **Wrap offering.json**: Updated description and fee structure (0.1 fixed → 1% percentage)
- **Bridge offering.json**: Updated fee structure (0.2 fixed → 1% percentage)

## Notable Implementation Details
- Native token detection uses zero address (`0x0000000000000000000000000000000000000000`)
- ERC-20 approvals use max uint256 for unlimited allowance
- Transaction execution includes gas limit and gas price from LI.FI quote if available
- Dry-run mode returns full quote and approval details without broadcasting
- All chain operations use viem's `getAddress()` for checksum validation

https://claude.ai/code/session_0122DuDUpnx8E9SjRVDemW4A